### PR TITLE
Add { descending: true } option

### DIFF
--- a/lib/chai-sorted.js
+++ b/lib/chai-sorted.js
@@ -2,7 +2,12 @@
 var isSorted = require('./is.sorted')
 
 var chaiIsSorted = function (chai, array, options) {
-  var useDescendingOrder = typeof options !== 'undefined' ? !!options.descending : false
+  var useDescendingOrder = typeof options === 'object' ? !!options.descending : false
+
+  // Backwards compatibility
+  if (typeof options === 'boolean') {
+    useDescendingOrder = options
+  }
 
   var Assertion = chai.Assertion
   new Assertion(array).to.be.a('array')

--- a/lib/chai-sorted.js
+++ b/lib/chai-sorted.js
@@ -1,7 +1,9 @@
 'use strict'
 var isSorted = require('./is.sorted')
 
-var chaiIsSorted = function (chai, array, useDescendingOrder) {
+var chaiIsSorted = function (chai, array, options) {
+  var useDescendingOrder = typeof options !== 'undefined' ? !!options.descending : false
+
   var Assertion = chai.Assertion
   new Assertion(array).to.be.a('array')
 
@@ -13,36 +15,36 @@ var chaiIsSorted = function (chai, array, useDescendingOrder) {
 }
 
 module.exports = function (chai, utils) {
-  chai.Assertion.addMethod('sorted', function (useDescendingOrder) {
-    chaiIsSorted.call(this, chai, this._obj, useDescendingOrder)
+  chai.Assertion.addMethod('sorted', function (options) {
+    chaiIsSorted.call(this, chai, this._obj, options)
   })
 
   utils.addProperty(chai.Assertion.prototype, 'descending', function () {
-    chaiIsSorted.call(this, chai, this._obj, true)
+    chaiIsSorted.call(this, chai, this._obj, { descending: true })
   })
 
   utils.addProperty(chai.Assertion.prototype, 'ascending', function () {
-    chaiIsSorted.call(this, chai, this._obj, false)
+    chaiIsSorted.call(this, chai, this._obj)
   })
 
-  chai.Assertion.addMethod('sortedBy', function (key, useDescendingOrder) {
+  chai.Assertion.addMethod('sortedBy', function (key, options) {
     var array = utils.flag(this, 'object').map(function (item) {
       return item[key]
     })
-    chaiIsSorted.call(this, chai, array, useDescendingOrder)
+    chaiIsSorted.call(this, chai, array, options)
   })
 
   chai.Assertion.addMethod('descendingBy', function (key) {
     var array = utils.flag(this, 'object').map(function (item) {
       return item[key]
     })
-    chaiIsSorted.call(this, chai, array, true)
+    chaiIsSorted.call(this, chai, array, { descending: true })
   })
 
   chai.Assertion.addMethod('ascendingBy', function (key) {
     var array = utils.flag(this, 'object').map(function (item) {
       return item[key]
     })
-    chaiIsSorted.call(this, chai, array, false)
+    chaiIsSorted.call(this, chai, array)
   })
 }

--- a/test/chai-sorted.js
+++ b/test/chai-sorted.js
@@ -22,6 +22,17 @@ describe('to.not.be.sorted() in ascending order', function () {
   // Additional condition testing of values is done in test/is.sorted.js
 })
 
+describe('Backwards compatibility', function () {
+  it('sorts in descending order with boolean argument', function () {
+    expect([3, 2, 1]).to.be.sorted(true)
+    expect(['b', 'apples']).to.be.sorted(true)
+    expect(['validCharacters', 'process', 'decal']).to.be.sorted(true)
+    expect([{id: 3}, {id: 2}, {id: 2}]).to.be.sortedBy('id', true)
+    expect([{id: 'c'}, {id: 'b'}, {id: 'a'}]).to.be.sortedBy('id', true)
+    expect([{id: 1, name: 'cat'}, {id: 34, name: 'bat'}, {id: 3, name: 'b'}, {size: 'large', name: 'apple'}]).to.be.sortedBy('name', true)
+  })
+})
+
 describe('to.be.sorted({ descending: true }) in descending order', function () {
   it('with array of numbers', function () {
     expect([3, 2, 1]).to.be.sorted({ descending: true })

--- a/test/chai-sorted.js
+++ b/test/chai-sorted.js
@@ -22,15 +22,15 @@ describe('to.not.be.sorted() in ascending order', function () {
   // Additional condition testing of values is done in test/is.sorted.js
 })
 
-describe('to.be.sorted(true) in descending order', function () {
+describe('to.be.sorted({ descending: true }) in descending order', function () {
   it('with array of numbers', function () {
-    expect([3, 2, 1]).to.be.sorted(true)
+    expect([3, 2, 1]).to.be.sorted({ descending: true })
   })
   it('with array of numbers', function () {
-    expect(['b', 'apples']).to.be.sorted(true)
+    expect(['b', 'apples']).to.be.sorted({ descending: true })
   })
   it('with array of words with mixed case', function () {
-    expect(['validCharacters', 'process', 'decal']).to.be.sorted(true)
+    expect(['validCharacters', 'process', 'decal']).to.be.sorted({ descending: true })
   })
   // Additional condition testing of values is done in test/is.sorted.js
 })
@@ -47,15 +47,21 @@ describe('to.be.sortedBy() in ascending order', function () {
   })
 })
 
+describe('to.be.sortedBy({ descending: false }) in ascending order', function () {
+  it('key id of numbers', function () {
+    expect([1, 2, 3]).to.be.sorted({ descending: false })
+  })
+})
+
 describe('to.be.sortedBy() in descending order', function () {
   it('key id of numbers', function () {
-    expect([{id: 3}, {id: 2}, {id: 2}]).to.be.sortedBy('id', true)
+    expect([{id: 3}, {id: 2}, {id: 2}]).to.be.sortedBy('id', { descending: true })
   })
   it('key id of strings', function () {
-    expect([{id: 'c'}, {id: 'b'}, {id: 'a'}]).to.be.sortedBy('id', true)
+    expect([{id: 'c'}, {id: 'b'}, {id: 'a'}]).to.be.sortedBy('id', { descending: true })
   })
   it('key name of words and letters', function () {
-    expect([{id: 1, name: 'cat'}, {id: 34, name: 'bat'}, {id: 3, name: 'b'}, {size: 'large', name: 'apple'}]).to.be.sortedBy('name', true)
+    expect([{id: 1, name: 'cat'}, {id: 34, name: 'bat'}, {id: 3, name: 'b'}, {size: 'large', name: 'apple'}]).to.be.sortedBy('name', { descending: true })
   })
 })
 


### PR DESCRIPTION
This makes it clearer what `true` or `false` means when sorting ascending/descending. It's an API breaking change but a worthy one IMO. I haven't thought too hard about the implementation so if I've missed anything obvious, please let me know and I'll fix it.

Closes #2 