### PR TITLE
added option to use a accessor function in sortedBy tests

### DIFF
--- a/lib/chai-sorted.js
+++ b/lib/chai-sorted.js
@@ -19,6 +19,18 @@ var chaiIsSorted = function (chai, array, options) {
   )
 }
 
+var sortBy = function (key) {
+  if (key instanceof Function) {
+    return function (item) {
+      return key(item)
+    }
+  } else {
+    return function (item) {
+      return item[key]
+    }
+  }
+}
+
 module.exports = function (chai, utils) {
   chai.Assertion.addMethod('sorted', function (options) {
     chaiIsSorted.call(this, chai, this._obj, options)
@@ -33,23 +45,17 @@ module.exports = function (chai, utils) {
   })
 
   chai.Assertion.addMethod('sortedBy', function (key, options) {
-    var array = utils.flag(this, 'object').map(function (item) {
-      return item[key]
-    })
+    var array = utils.flag(this, 'object').map(sortBy(key))
     chaiIsSorted.call(this, chai, array, options)
   })
 
   chai.Assertion.addMethod('descendingBy', function (key) {
-    var array = utils.flag(this, 'object').map(function (item) {
-      return item[key]
-    })
+    var array = utils.flag(this, 'object').map(sortBy(key))
     chaiIsSorted.call(this, chai, array, { descending: true })
   })
 
   chai.Assertion.addMethod('ascendingBy', function (key) {
-    var array = utils.flag(this, 'object').map(function (item) {
-      return item[key]
-    })
+    var array = utils.flag(this, 'object').map(sortBy(key))
     chaiIsSorted.call(this, chai, array)
   })
 }

--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,12 @@ Test for descending sort order of array by `name` attribute
 expect([{id:2,name:"bat"},{id:3,name:"apples"}]).to.be.sortedBy("name", {descending: true})
 ```
 
+Test for descending sort order of array using a function to access the `name` attribute
+
+```javascript
+expect([{id:2,name:"bat"},{id:3,name:"apples"}]).to.be.sortedBy((item) => item.name, {descending: true})
+```
+
 ### `.ascendingBy` method
 Alternate of `sortedBy` but more explicit
 
@@ -78,6 +84,12 @@ Test for ascending sort order of array by `name` attribute
 expect([{id:2,name:"apple"},{id:3,name:"bat"}]).to.be.ascendingBy("name")
 ```
 
+Test for ascending sort order of array using a function to access the `name` attribute
+
+```javascript
+expect([{id:2,name:"apple"},{id:3,name:"bat"}]).to.be.ascendingBy((item) => item.name)
+```
+
 ### `.descendingBy` method
 Alternate of `sortedBy` but does not require passing `true` as a second parameter to `sortedBy`. It is the same as doing `sortBy("name",true)`
 
@@ -85,6 +97,12 @@ Test for descending sort order of array by `name` attribute
 
 ```javascript
 expect([{id:2,name:"bat"},{id:3,name:"apples"}]).to.be.descendingBy("name")
+```
+
+Test for descending sort order of array using a function to access the `name` attribute
+
+```javascript
+expect([{id:2,name:"bat"},{id:3,name:"apples"}]).to.be.descendingBy((item) => item.name)
 ```
 
 ### `ascending` property

--- a/test/chai-sorted.js
+++ b/test/chai-sorted.js
@@ -56,6 +56,9 @@ describe('to.be.sortedBy() in ascending order', function () {
   it('key name of words and letters', function () {
     expect([{id: 1, name: 'a'}, {id: 34, name: 'apple'}, {id: 3, name: 'b'}, {size: 'large', name: 'ba'}]).to.be.sortedBy('name')
   })
+  it('key function accessor', function () {
+    expect([{id: 1, name: 'a'}, {id: 34, name: 'apple'}, {id: 3, name: 'b'}, {size: 'large', name: 'ba'}]).to.be.sortedBy(function (item) { return item.name })
+  })
 })
 
 describe('to.be.sortedBy({ descending: false }) in ascending order', function () {
@@ -73,6 +76,9 @@ describe('to.be.sortedBy() in descending order', function () {
   })
   it('key name of words and letters', function () {
     expect([{id: 1, name: 'cat'}, {id: 34, name: 'bat'}, {id: 3, name: 'b'}, {size: 'large', name: 'apple'}]).to.be.sortedBy('name', { descending: true })
+  })
+  it('key function accessor', function () {
+    expect([{id: 1, name: 'cat'}, {id: 34, name: 'bat'}, {id: 3, name: 'b'}, {size: 'large', name: 'apple'}]).to.be.sortedBy(function (item) { return item.name }, { descending: true })
   })
 })
 
@@ -119,6 +125,9 @@ describe('to.be.descendingBy(property)', function () {
   it('key name of words and letters', function () {
     expect([{id: 1, name: 'cat'}, {id: 34, name: 'c'}, {id: 3, name: 'boy'}, {size: 'large', name: 'b'}]).to.be.descendingBy('name')
   })
+  it('key function accessor', function () {
+    expect([{id: 1, name: 'cat'}, {id: 34, name: 'c'}, {id: 3, name: 'boy'}, {size: 'large', name: 'b'}]).to.be.descendingBy(function (item) { return item.name })
+  })
 })
 
 describe('to.be.ascendingBy(property)', function () {
@@ -130,5 +139,8 @@ describe('to.be.ascendingBy(property)', function () {
   })
   it('key name of words and letters', function () {
     expect([{id: 1, name: 'a'}, {id: 34, name: 'boy'}, {id: 3, name: 'c'}, {size: 'large', name: 'cat'}]).to.be.ascendingBy('name')
+  })
+  it('key function accessor', function () {
+    expect([{id: 1, name: 'a'}, {id: 34, name: 'boy'}, {id: 3, name: 'c'}, {size: 'large', name: 'cat'}]).to.be.ascendingBy(function (item) { return item.name })
   })
 })


### PR DESCRIPTION
in case you work with complex options you need a custom accessor function to determine by which property or method call value the array is expected to be sorted.

this patch adds the option to usea accessor function everywhere you could use only an id-string before.